### PR TITLE
fix issue when custom theme is inside default theme path

### DIFF
--- a/Fix-SplitPanePersistence.ps1
+++ b/Fix-SplitPanePersistence.ps1
@@ -602,12 +602,12 @@ if ($ompInstalled) {
         
         # Step 4: Get and ensure writable theme
         $profileContent = Get-Content $profilePath -Raw
-        $themePath = Get-ThemePathFromProfile -ProfileContent $profileContent
-        Write-Log "Detected theme path: $themePath" -Verbose
-        
-        if ($themePath) {
-            $writableThemePath = Ensure-ThemeIsWritable -ProfilePath $profilePath -CurrentThemePath $themePath
-            
+        $detectedThemePath = Get-ThemePathFromProfile -ProfileContent $profileContent
+        Write-Log "Detected theme path: $detectedThemePath" -Verbose
+
+        if ($detectedThemePath) {
+            $writableThemePath = Ensure-ThemeIsWritable -ProfilePath $profilePath -CurrentThemePath $detectedThemePath
+
             # Step 5: Update theme pwd setting
             if ($writableThemePath) {
                 $null = Update-ThemePwd -ThemePath $writableThemePath


### PR DESCRIPTION
PowerShell variable names are case-insensitive. In the main execution block, the local variable `$themePath` was assigned the detected theme path from the user's profile:

```powershell
$themePath = Get-ThemePathFromProfile -ProfileContent $profileContent
```

Because PowerShell treats `$themePath` and the script parameter `$ThemePath` as the same variable, this silently overwrote the parameter with the full path to the theme file (e.g. `C:\...\themes\mycustomtheme.omp.json`).

`Get-UserThemePath` then checks `if ($ThemePath)` to determine whether the user supplied a custom directory override via `-ThemePath`. With the collision, it found the file path and used it as a *directory*, producing:

```
Join-Path "C:\...\themes\mycustomtheme.omp.json" "mycustomtheme.omp.json"
→ "C:\...\themes\mycustomtheme.omp.json\mycustomtheme.omp.json"
```

**Fix.** Rename the local variable to `$detectedThemePath` to avoid the collision.